### PR TITLE
Fix Bug with polymorphic fields and empty values

### DIFF
--- a/amaxa/amaxa.py
+++ b/amaxa/amaxa.py
@@ -717,6 +717,10 @@ class ExtractionStep(Step):
         # references to records above us in the extraction hierarchy, but that weren't extracted already.
         for f in self.descendent_lookups:
             lookup_value = result[f]
+
+            if (lookup_value == None):
+                continue
+
             if len(field_map[f]['referenceTo']) == 1:
                 target_sobject = field_map[f]['referenceTo'][0]
             else:

--- a/amaxa/test/test_ExtractionStep.py
+++ b/amaxa/test/test_ExtractionStep.py
@@ -153,6 +153,13 @@ class test_ExtractionStep(unittest.TestCase):
         oc.add_dependency.reset_mock()
         oc.store_result.reset_mock()
 
+        # Validate that the polymorphic lookup is treated properly when the id is None
+        step.store_result({ 'Id': '001000000000000', 'Lookup__c': None, 'Name': 'Kara Thrace' })
+        oc.add_dependency.assert_not_called()
+        oc.store_result.assert_called_once_with('Contact', { 'Id': '001000000000000', 'Lookup__c': None, 'Name': 'Kara Thrace' })
+        oc.add_dependency.reset_mock()
+        oc.store_result.reset_mock()
+
         # Validate that the polymorphic lookup is treated properly when the content is a off-extraction reference
         step.store_result({ 'Id': '001000000000000', 'Lookup__c': '00T000000000001', 'Name': 'Kara Thrace' })
         oc.add_dependency.assert_not_called()


### PR DESCRIPTION
The extraction would crash if the value was null in a polymorphic lookup. The reason is that when the lookup is polymorphic, the concrete type is inferred from the id that is null, causing the app to crash.