### PR TITLE
Add dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu
+
+FROM python
+
+RUN pip install --upgrade pip
+
+WORKDIR /amaxa
+
+COPY . /amaxa
+
+RUN pip install amaxa
+
+# TODO: add environmental variables from .envrc directly
+# google "dockerfile .envrc best practice"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,3 @@ WORKDIR /amaxa
 COPY . /amaxa
 
 RUN pip install amaxa
-
-# TODO: add environmental variables from .envrc directly
-# google "dockerfile .envrc best practice"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Make sure to invoke within a Python 3.6+ virtual environment or specify Python 3
 
 Amaxa is operating system-agnostic. It has been tested primarily on Linux but is also known to work in a MINGW Windows 7 environment.
 
+Using Amaxa within Docker, execute
+
+    $ docker build -t amaxa:my_local_amaxa .
+   
+To start the container such that you could run Amaxa commands, execute
+
+    $ docker run -it amaxa:my_local_amaxa bash
+
 ### Development
 
 To start working with Amaxa in a virtual environment, clone the Git repository. Then, create a virtual environment for Amaxa and install there:


### PR DESCRIPTION
I ran into an issue with my python 2 versus python 3 locally and tripped down the rabbit hole of pyenv. My solution was to build a docker container with ubuntu and python and thought this might be helpful for other folks using amaxa.

Concerns I have with the current solution:

* I wasn't sure what the level of documentation for docker should be, as it currently stands, the readme file's explanation is pretty bare bones. I'm happy to fill this out more.
* I'm not clear on how to run the `.gitlab-ci.yml` to run the tests. I haven't run the tests at all as of yet.
* To run the amaxa commands I've added a volume to the assets folder locally. The below convention has been working for me, i'm happy to add this to the readme file.
```docker run -it -v amaxa/assets:/amaxa/assets/ amaxa:my_local_amaxa bash```