### PR TITLE
Extensible Transforms

### DIFF
--- a/amaxa/loader/core.py
+++ b/amaxa/loader/core.py
@@ -148,12 +148,18 @@ class OperationLoader(Loader):
                     if "transforms" in f:
                         field_name = f[source] if source in f else f[dest]
                         mapper.field_transforms[field_name] = [
-                            getattr(transforms, t) for t in f["transforms"]
+                            self._build_transform(field_name, t)
+                            for t in f["transforms"]
                         ]
 
             return mapper
 
         return None
+
+    def _build_transform(self, field_name, transform):
+        transform_factory = transforms.get_all_transforms()[transform["name"]]
+
+        return transform_factory.get_transform(field_name, transform["options"])
 
     def _populate_lookup_behaviors(self, step, entry):
         if "fields" in entry and any(

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -350,7 +350,7 @@ SCHEMAS = {
         2: {
             "version": {"type": "integer", "required": True, "allowed": [2]},
             "options": OPTIONS_SCHEMA,
-            "plugin_modules": {
+            "plugin-modules": {
                 "type": "list",
                 "schema": {"type": "string", "check_with": _validate_import_module},
             },

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import sys
 
 import cerberus
 
@@ -35,6 +36,8 @@ def _coerce_transform(trans):
 
 def _validate_import_module(field, value, error):
     try:
+        if "." not in sys.path:
+            sys.path.append(".")
         importlib.import_module(value)
     except ImportError:
         error(field, f"Unable to import module {value}")

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -1,4 +1,7 @@
+import importlib
 import os
+
+import cerberus
 
 from .. import amaxa, constants, transforms
 from .input_type import InputType
@@ -21,6 +24,45 @@ def _env_or_string(params):
     ret.update(params)
 
     return ret
+
+
+def _coerce_transform(trans):
+    if isinstance(trans, str):
+        return {"name": trans, "options": {}}
+
+    return trans
+
+
+def _validate_import_module(field, value, error):
+    try:
+        importlib.import_module(value)
+    except ImportError:
+        error(field, f"Unable to import module {value}")
+
+
+def _validate_transform_options(field, value, error):
+    # value will be a dict with keys "name" and "options"
+
+    transform_name = value["name"]
+    options = value["options"]
+
+    available_transforms = transforms.get_all_transforms()
+
+    if transform_name not in available_transforms:
+        error(field, f"The transform {transform_name} does not exist.")
+
+    if options:
+        validator = cerberus.Validator(
+            available_transforms[transform_name].get_options_schema()
+        )
+        validator.validate(value)
+
+        if validator.errors:
+            errors = "\n".join(validator.errors)
+            error(
+                field,
+                f"The options schema for transform {transform_name} failed to validate: {errors}",
+            )
 
 
 OPTIONS_SCHEMA = {
@@ -300,6 +342,10 @@ SCHEMAS = {
         2: {
             "version": {"type": "integer", "required": True, "allowed": [2]},
             "options": OPTIONS_SCHEMA,
+            "plugin_modules": {
+                "type": "list",
+                "schema": {"type": "string", "check_with": _validate_import_module},
+            },
             "operation": {
                 "type": "list",
                 "schema": {
@@ -371,8 +417,16 @@ SCHEMAS = {
                                     "transforms": {
                                         "type": "list",
                                         "schema": {
-                                            "type": "string",
-                                            "allowed": transforms.__all__,
+                                            "type": ["dict", "string"],
+                                            "schema": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "required": True,
+                                                },
+                                                "options": {"type": "dict"},
+                                            },
+                                            "coerce": _coerce_transform,
+                                            "check_with": _validate_transform_options,
                                         },
                                         "required": False,
                                     },

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -50,19 +50,19 @@ def _validate_transform_options(field, value, error):
 
     if transform_name not in available_transforms:
         error(field, f"The transform {transform_name} does not exist.")
+        return
 
-    if options:
-        validator = cerberus.Validator(
-            available_transforms[transform_name].get_options_schema()
+    validator = cerberus.Validator(
+        available_transforms[transform_name].get_options_schema()
+    )
+    validator.validate(options)
+
+    if validator.errors:
+        errors = "\n".join(validator.errors)
+        error(
+            field,
+            f"The options schema for transform {transform_name} failed to validate: {errors}",
         )
-        validator.validate(value)
-
-        if validator.errors:
-            errors = "\n".join(validator.errors)
-            error(
-                field,
-                f"The options schema for transform {transform_name} failed to validate: {errors}",
-            )
 
 
 OPTIONS_SCHEMA = {

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -320,7 +320,12 @@ SCHEMAS = {
                                         "type": "list",
                                         "schema": {
                                             "type": "string",
-                                            "allowed": transforms.__all__,
+                                            "allowed": [
+                                                "strip",
+                                                "lowercase",
+                                                "uppercase",
+                                            ],
+                                            "coerce": _coerce_transform,
                                         },
                                         "required": False,
                                     },

--- a/amaxa/transforms.py
+++ b/amaxa/transforms.py
@@ -1,8 +1,12 @@
 from abc import ABCMeta, abstractmethod
 from typing import Dict
 
+_all_transforms = None
+
 
 def get_all_transforms():
+    global _all_transforms
+
     def get_subclasses(cls):
         classes = []
         for subclass in cls.__subclasses__():
@@ -11,7 +15,12 @@ def get_all_transforms():
 
         return classes
 
-    return {cls.transform_name: cls for cls in get_subclasses(TransformProvider)}
+    if _all_transforms is None:
+        _all_transforms = {
+            cls.transform_name: cls() for cls in get_subclasses(TransformProvider)
+        }
+
+    return _all_transforms
 
 
 class TransformProvider(metaclass=ABCMeta):
@@ -19,7 +28,7 @@ class TransformProvider(metaclass=ABCMeta):
     allowed_types = []
 
     @abstractmethod
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         pass
 
     @abstractmethod
@@ -31,7 +40,7 @@ class LowercaseTransformProvider(TransformProvider):
     transform_name = "lowercase"
     allowed_types = ["xsd:string"]
 
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         def lowercase(x):
             return x.lower()
 
@@ -45,7 +54,7 @@ class UppercaseTransformProvider(TransformProvider):
     transform_name = "uppercase"
     allowed_types = ["xsd:string"]
 
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         def uppercase(x):
             return x.upper()
 
@@ -59,7 +68,7 @@ class StripTransformProvider(TransformProvider):
     transform_name = "strip"
     allowed_types = ["xsd:string"]
 
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         def strip(x):
             return x.strip()
 
@@ -73,7 +82,7 @@ class PrefixTransformProvider(TransformProvider):
     transform_name = "prefix"
     allowed_types = ["xsd:string"]
 
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         def prefix(x):
             return options["prefix"] + x
 
@@ -87,7 +96,7 @@ class SuffixTransformProvider(TransformProvider):
     transform_name = "suffix"
     allowed_types = ["xsd:string"]
 
-    def get_transform(self, field_context: Dict, options: Dict):
+    def get_transform(self, field_context: str, options: Dict):
         def suffix(x):
             return x + options["suffix"]
 

--- a/amaxa/transforms.py
+++ b/amaxa/transforms.py
@@ -38,7 +38,6 @@ class TransformProvider(metaclass=ABCMeta):
 
 class LowercaseTransformProvider(TransformProvider):
     transform_name = "lowercase"
-    allowed_types = ["xsd:string"]
 
     def get_transform(self, field_context: str, options: Dict):
         def lowercase(x):
@@ -52,7 +51,6 @@ class LowercaseTransformProvider(TransformProvider):
 
 class UppercaseTransformProvider(TransformProvider):
     transform_name = "uppercase"
-    allowed_types = ["xsd:string"]
 
     def get_transform(self, field_context: str, options: Dict):
         def uppercase(x):
@@ -66,7 +64,6 @@ class UppercaseTransformProvider(TransformProvider):
 
 class StripTransformProvider(TransformProvider):
     transform_name = "strip"
-    allowed_types = ["xsd:string"]
 
     def get_transform(self, field_context: str, options: Dict):
         def strip(x):
@@ -80,7 +77,6 @@ class StripTransformProvider(TransformProvider):
 
 class PrefixTransformProvider(TransformProvider):
     transform_name = "prefix"
-    allowed_types = ["xsd:string"]
 
     def get_transform(self, field_context: str, options: Dict):
         def prefix(x):
@@ -94,7 +90,6 @@ class PrefixTransformProvider(TransformProvider):
 
 class SuffixTransformProvider(TransformProvider):
     transform_name = "suffix"
-    allowed_types = ["xsd:string"]
 
     def get_transform(self, field_context: str, options: Dict):
         def suffix(x):

--- a/amaxa/transforms.py
+++ b/amaxa/transforms.py
@@ -1,13 +1,97 @@
-__all__ = ["strip", "lowercase", "uppercase"]
+from abc import ABCMeta, abstractmethod
+from typing import Dict
 
 
-def strip(x):
-    return x.strip()
+def get_all_transforms():
+    def get_subclasses(cls):
+        classes = []
+        for subclass in cls.__subclasses__():
+            classes.append(subclass)
+            classes.extend(get_subclasses(subclass))
+
+        return classes
+
+    return {cls.transform_name: cls for cls in get_subclasses(TransformProvider)}
 
 
-def lowercase(x):
-    return x.lower()
+class TransformProvider(metaclass=ABCMeta):
+    transform_name = ""
+    allowed_types = []
+
+    @abstractmethod
+    def get_transform(self, field_context: Dict, options: Dict):
+        pass
+
+    @abstractmethod
+    def get_options_schema(self):
+        pass
 
 
-def uppercase(x):
-    return x.upper()
+class LowercaseTransformProvider(TransformProvider):
+    transform_name = "lowercase"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: Dict, options: Dict):
+        def lowercase(x):
+            return x.lower()
+
+        return lowercase
+
+    def get_options_schema(self):
+        return {}
+
+
+class UppercaseTransformProvider(TransformProvider):
+    transform_name = "uppercase"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: Dict, options: Dict):
+        def uppercase(x):
+            return x.upper()
+
+        return uppercase
+
+    def get_options_schema(self):
+        return {}
+
+
+class StripTransformProvider(TransformProvider):
+    transform_name = "strip"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: Dict, options: Dict):
+        def strip(x):
+            return x.strip()
+
+        return strip
+
+    def get_options_schema(self):
+        return {}
+
+
+class PrefixTransformProvider(TransformProvider):
+    transform_name = "prefix"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: Dict, options: Dict):
+        def prefix(x):
+            return options["prefix"] + x
+
+        return prefix
+
+    def get_options_schema(self):
+        return {"prefix": {"type": "string", "required": True}}
+
+
+class SuffixTransformProvider(TransformProvider):
+    transform_name = "suffix"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: Dict, options: Dict):
+        def suffix(x):
+            return x + options["suffix"]
+
+        return suffix
+
+    def get_options_schema(self):
+        return {"suffix": {"type": "string", "required": True}}

--- a/amaxa/transforms.py
+++ b/amaxa/transforms.py
@@ -31,9 +31,8 @@ class TransformProvider(metaclass=ABCMeta):
     def get_transform(self, field_context: str, options: Dict):
         pass
 
-    @abstractmethod
     def get_options_schema(self):
-        pass
+        return {}
 
 
 class LowercaseTransformProvider(TransformProvider):
@@ -45,9 +44,6 @@ class LowercaseTransformProvider(TransformProvider):
 
         return lowercase
 
-    def get_options_schema(self):
-        return {}
-
 
 class UppercaseTransformProvider(TransformProvider):
     transform_name = "uppercase"
@@ -58,9 +54,6 @@ class UppercaseTransformProvider(TransformProvider):
 
         return uppercase
 
-    def get_options_schema(self):
-        return {}
-
 
 class StripTransformProvider(TransformProvider):
     transform_name = "strip"
@@ -70,9 +63,6 @@ class StripTransformProvider(TransformProvider):
             return x.strip()
 
         return strip
-
-    def get_options_schema(self):
-        return {}
 
 
 class PrefixTransformProvider(TransformProvider):

--- a/assets/test_data_transforms/Account.csv
+++ b/assets/test_data_transforms/Account.csv
@@ -1,8 +1,5 @@
 Id,Description,Name
-0011R00001ypMKsQAM,Lifestyle,Testcorp
 0013600001excS5AAI,Lifestyle,Sandia Style Interiors
 0013600001lwxdQAAQ,VC,Europa Ventures
 0013600001lwmWoAAI,Government,FedCo
-0013600001lwmUnAAI,VC,Coastal Corp.
-0013600001lwxcXAAQ,VC,Bay Partners
 0013600001exbKeAAI,Sustainability,High Desert Inc.

--- a/assets/test_data_transforms/Account.csv
+++ b/assets/test_data_transforms/Account.csv
@@ -1,0 +1,8 @@
+Id,Description,Name
+0011R00001ypMKsQAM,Lifestyle,Testcorp
+0013600001excS5AAI,Lifestyle,Sandia Style Interiors
+0013600001lwxdQAAQ,VC,Europa Ventures
+0013600001lwmWoAAI,Government,FedCo
+0013600001lwmUnAAI,VC,Coastal Corp.
+0013600001lwxcXAAQ,VC,Bay Partners
+0013600001exbKeAAI,Sustainability,High Desert Inc.

--- a/assets/test_data_transforms/about.md
+++ b/assets/test_data_transforms/about.md
@@ -1,0 +1,21 @@
+# About this Test Data Suite
+
+This test data suite is a demonstration of using Amaxa to apply both custom and built-in transformations on data during load and extract operations. A set of example data is included in CSV format and can be loaded to a Salesforce DX scratch org. It's used as part of Amaxa's automated tests, and can also be used to experiment.
+
+The `test.yml` file defines an operation that loads only one sObject (`Account`). It applies two transformations: the `Name` field is lowercased, and a custom transformation (defined in `test_transforms.py`) called `multiply` is applied to the `Description` field. `multiply` takes options in the operation definition, here an integer `count` for how many times to repeat the content of the field.
+
+`test_transforms.py` is an example of how to implement your own transform logic for data operations. Note that the operation definition loads this file via the `plugin-modules` key.
+
+To try out loading the sample data set, spin up a Salesforce DX scratch org, sandbox, or developer org, and place the credentials in a `credentials.yml` file (an empty template is included). If using a Salesforce DX org, give the org the alias `amaxa`, and use the `credentials-sfdx.yml` file to automatically authenticate into it.
+
+Then, change into the `test_data_transforms` directory and do
+
+    amaxa --load --credentials credentials.yml test.yml
+
+and view the results in your scratch org.
+
+You can also do
+
+    amaxa --credentials credentials.yml test.yml
+
+to replace the test data with data pulled from your target org.

--- a/assets/test_data_transforms/credentials-env.yml
+++ b/assets/test_data_transforms/credentials-env.yml
@@ -1,0 +1,7 @@
+version: 2
+credentials:
+    token:
+        access-token:
+            env: 'ACCESS_TOKEN'
+        instance-url:
+            env: 'INSTANCE_URL'

--- a/assets/test_data_transforms/credentials-sfdx.yml
+++ b/assets/test_data_transforms/credentials-sfdx.yml
@@ -1,0 +1,3 @@
+version: 2
+credentials:
+    sfdx: amaxa

--- a/assets/test_data_transforms/test.yml
+++ b/assets/test_data_transforms/test.yml
@@ -1,5 +1,5 @@
 version: 2
-plugin_modules:
+plugin-modules:
     - test_transforms
 operation:
     - sobject: Account

--- a/assets/test_data_transforms/test.yml
+++ b/assets/test_data_transforms/test.yml
@@ -1,0 +1,14 @@
+version: 2
+plugin_modules:
+    - test_transforms
+operation:
+    - sobject: Account
+      fields:
+        - Name
+        - field: Description
+          transforms:
+            - name: multiply
+              options:
+                count: 2
+      extract:
+        all: True

--- a/assets/test_data_transforms/test.yml
+++ b/assets/test_data_transforms/test.yml
@@ -4,7 +4,9 @@ plugin_modules:
 operation:
     - sobject: Account
       fields:
-        - Name
+        - field: Name
+          transforms:
+            - lowercase
         - field: Description
           transforms:
             - name: multiply

--- a/assets/test_data_transforms/test_transforms.py
+++ b/assets/test_data_transforms/test_transforms.py
@@ -1,0 +1,16 @@
+from amaxa.transforms import TransformProvider
+from typing import Dict
+
+
+class MultiplyTransformer(TransformProvider):
+    transform_name = "multiply"
+    allowed_types = ["xsd:string"]
+
+    def get_transform(self, field_context: str, options: Dict):
+        def multiply(x):
+            return x * options["count"]
+
+        return multiply
+
+    def get_options_schema(self):
+        return {"count": {"type": "integer", "required": True}}

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,4 +1,4 @@
 Example Data and Test Suites
 ----------------------------
 
-Two example data suites and operation definition files are included with Amaxa in the ``assets`` directory. See ``about.md`` in each directory for information about what the data suite includes and tests and how to use it.
+Three example data suites and operation definition files are included with Amaxa in the ``assets`` directory. See ``about.md`` in each directory for information about what the data suite includes and tests and how to use it.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    running
    credentials
    operations
+   transforms
    validation
    references
    errors

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -1,0 +1,49 @@
+Data Transforms
+---------------
+
+Introduction
+************
+
+Amaxa supports applying *transforms* to data values during both extraction and load operations. Transforms are specified at the field level in the operation definition file.
+
+.. code-block:: yaml
+
+    version: 2
+    plugin-modules:
+        - test_transforms
+    operation:
+        - sobject: Account
+        fields:
+            - field: Name
+              transforms:
+                - uppercase
+                - name: suffix
+                  options:
+                    suffix: "-CLIENT"
+        extract:
+            all: True
+
+In this example, the `Name` field on `Account` has two transforms applied to it: ``uppercase`` and ``suffix``. Transforms are applied sequentially, and can take options as shown above. Loading an Account with the Name "Acme Products" (in its CSV file) via the operation definition shown above would yield an Account named "ACME PRODUCTS-CLIENT" in the target Salesforce org.
+
+Transforms are bidirectional: they run on both load and extract.
+
+Amaxa ships with five transforms:
+
+- ``uppercase`` uppercases the field value.
+- ``lowercase`` lowercases the string value.
+- ``strip`` removes leading and trailing whitespace.
+- ``prefix`` adds a prefix string (specified with the ``options`` key ``prefix``).
+- ``suffix`` adds a suffix string (specified with the ``options`` key ``suffix``).
+
+Custom Transforms
+*****************
+
+Amaxa also supports custom transforms. To implement a custom transformation, create a Python module containing a class that subclasses ``amaxa.transforms.TransformProvider``. Subclasses must populate the ``transform_name`` class attribute and override two methods, ``get_transform()`` and ``get_options_schema()``.
+
+``get_transform()`` accepts the API name of the configured field and a ``dict`` containing the user-specified options, if any. It returns a callable that will be invoked with a single parameter, the field value, each time the transform is used.
+
+``get_options_schema()`` returns the schema by which the user-specifiable options will be validated in the operation definition. This is a `Cerberus <https://docs.python-cerberus.org/>`_ schema that should validate a ``dict``.
+
+Before being used in an operation, custom transforms must be loaded by specifying them in a ``plugin-modules`` list at the top level of the YAML configuration. Specify the name of the containing module, not the transform class; Amaxa will automatically discover transforms in those modules. Modules may be located in the current working directory or anywhere in the Python search path.
+
+A complete example of using a custom transform is included in Amaxa's repository in the ``assets/test_data_transforms`` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "amaxa"
-version = "0.9.5"
+version = "0.9.6"
 description = "Load and extract data from multiple Salesforce objects in a single operation, preserving links and network structure."
 license = "BSD-3-Clause"
 authors = ["David Reed <david@ktema.org>"]

--- a/test/test_org/test_end_to_end.py
+++ b/test/test_org/test_end_to_end.py
@@ -97,7 +97,7 @@ class test_end_to_end_transforms(IntegrationTest):
                     self.assertEqual(0, main())
 
                 result = self.connection.query(
-                    "SELECT Name, Description FROM Account WHERE Name = 'Sandia Style Interiors'"
+                    "SELECT Id, Name, Description FROM Account WHERE Name = 'Sandia Style Interiors'"
                 )
                 assert len(result["records"]) == 1
                 record = result["records"][0]

--- a/test/test_org/test_end_to_end.py
+++ b/test/test_org/test_end_to_end.py
@@ -83,3 +83,47 @@ class test_end_to_end(IntegrationTest):
 
                     self.assertFalse(names[sobject])
                     self.assertEqual(0, counts[sobject])
+
+
+class test_end_to_end_transforms(IntegrationTest):
+    def test_round_trip_all_transforms(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            copy_tree("assets/test_data_transforms", tempdir)
+            with cd(tempdir):
+                with unittest.mock.patch(
+                    "sys.argv",
+                    ["amaxa", "--load", "-c", "credentials-env.yml", "test.yml"],
+                ):
+                    self.assertEqual(0, main())
+
+                result = self.connection.query(
+                    "SELECT Name, Description FROM Account WHERE Name = 'Sandia Style Interiors'"
+                )
+                assert len(result["records"]) == 1
+                record = result["records"][0]
+                assert record["Name"] == "sandia style interiors"
+                assert record["Description"] == "LifestyleLifestyle"
+
+                self.connection.Account.update(
+                    record["Id"], {"Name": record["Name"].upper()}
+                )
+
+                # Re-extract the data.
+                with unittest.mock.patch(
+                    "sys.argv", ["amaxa", "-c", "credentials-env.yml", "test.yml"]
+                ):
+                    self.assertEqual(0, main())
+
+                # Validate the results
+                with open("Account.csv", "r") as csv_file:
+                    reader = csv.DictReader(csv_file)
+                    for record in reader:
+                        self.register_case_record("Account", record["Id"])
+
+                        assert record["Name"].islower()
+                        assert record["Description"] in [
+                            "Lifestyle" * 4,
+                            "VC" * 4,
+                            "Government" * 4,
+                            "Sustainability" * 4,
+                        ]

--- a/test/test_unit/test_DataMapper.py
+++ b/test/test_unit/test_DataMapper.py
@@ -1,7 +1,6 @@
 import unittest
 
 import amaxa
-from amaxa import transforms
 
 
 class test_DataMapper(unittest.TestCase):
@@ -13,14 +12,15 @@ class test_DataMapper(unittest.TestCase):
 
     def test_transform_value_applies_transformations(self):
         mapper = amaxa.DataMapper(
-            {}, {"Test__c": [transforms.strip, transforms.lowercase]}
+            {}, {"Test__c": [lambda x: x.strip(), lambda x: x.lower()]}
         )
 
         self.assertEqual("value", mapper.transform_value("Test__c", " VALUE  "))
 
     def test_transform_record_does(self):
         mapper = amaxa.DataMapper(
-            {"Test__c": "Value"}, {"Test__c": [transforms.strip, transforms.lowercase]}
+            {"Test__c": "Value"},
+            {"Test__c": [lambda x: x.strip(), lambda x: x.lower()]},
         )
 
         self.assertEqual(

--- a/test/test_unit/test_ExtractionOperationLoader.py
+++ b/test/test_unit/test_ExtractionOperationLoader.py
@@ -245,7 +245,7 @@ class test_ExtractionOperationLoader(unittest.TestCase):
     def test_load_extraction_operation_creates_export_mapper(self):
         result = self._run_success_test(
             {
-                "version": 1,
+                "version": 2,
                 "operation": [
                     {
                         "sobject": "Account",
@@ -253,7 +253,10 @@ class test_ExtractionOperationLoader(unittest.TestCase):
                             {
                                 "field": "Name",
                                 "column": "Account Name",
-                                "transforms": ["strip", "lowercase"],
+                                "transforms": [
+                                    {"name": "strip", "options": {}},
+                                    {"name": "lowercase", "options": {}},
+                                ],
                             },
                             "Industry",
                         ],

--- a/test/test_unit/test_OperationLoader.py
+++ b/test/test_unit/test_OperationLoader.py
@@ -62,7 +62,10 @@ class test_OperationLoader(unittest.TestCase):
                 {
                     "field": "Name",
                     "column": "Account Name",
-                    "transforms": ["strip", "lowercase"],
+                    "transforms": [
+                        {"name": "strip", "options": {}},
+                        {"name": "lowercase", "options": {}},
+                    ],
                 },
                 "Industry",
             ],
@@ -88,7 +91,10 @@ class test_OperationLoader(unittest.TestCase):
                 {
                     "field": "Name",
                     "column": "Account Name",
-                    "transforms": ["strip", "lowercase"],
+                    "transforms": [
+                        {"name": "strip", "options": {}},
+                        {"name": "lowercase", "options": {}},
+                    ],
                 },
                 "Industry",
             ],
@@ -111,7 +117,13 @@ class test_OperationLoader(unittest.TestCase):
         ex = {
             "sobject": "Account",
             "fields": [
-                {"field": "Name", "transforms": ["strip", "lowercase"]},
+                {
+                    "field": "Name",
+                    "transforms": [
+                        {"name": "strip", "options": {}},
+                        {"name": "lowercase", "options": {}},
+                    ],
+                },
                 "Industry",
             ],
             "extract": {"all": True},

--- a/test/test_unit/test_schemas.py
+++ b/test/test_unit/test_schemas.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+from amaxa.loader import schemas
+
+
+def test_coerce_transform():
+    assert schemas._coerce_transform("strip") == {"name": "strip", "options": {}}
+    assert schemas._coerce_transform({"name": "strip", "options": {}}) == {
+        "name": "strip",
+        "options": {},
+    }
+
+
+def test_validate_import_module__failure():
+    error = Mock()
+    field = Mock()
+
+    schemas._validate_import_module(field, "///__none__", error)
+    error.assert_called_once_with(field, "Unable to import module ///__none__")
+
+
+def test_validate_import_module__success():
+    error = Mock()
+    field = Mock()
+
+    schemas._validate_import_module(field, "os", error)
+    error.assert_not_called()
+
+
+def test_validate_transform_options():
+    error = Mock()
+    field = Mock()
+
+    schemas._validate_transform_options(
+        field, {"name": "suffix", "options": {"suffix": "test"}}, error
+    )
+
+    error.assert_not_called()
+
+
+def test_validate_transform_options__missing_transform():
+    error = Mock()
+    field = Mock()
+
+    schemas._validate_transform_options(
+        field, {"name": "__bogus", "options": {}}, error
+    )
+    error.assert_called_once_with(field, "The transform __bogus does not exist.")
+
+
+def test_validate_transform_options__invalid_options():
+    error = Mock()
+    field = Mock()
+
+    schemas._validate_transform_options(field, {"name": "suffix", "options": {}}, error)
+    error.assert_called_once_with(
+        field, "The options schema for transform suffix failed to validate: suffix",
+    )

--- a/test/test_unit/test_transforms.py
+++ b/test/test_unit/test_transforms.py
@@ -4,7 +4,47 @@ from amaxa import transforms
 
 
 class test_transforms(unittest.TestCase):
-    def test_transforms(self):
-        self.assertEqual("test", transforms.strip("  test  "))
-        self.assertEqual("test", transforms.lowercase("TEst"))
-        self.assertEqual("TEST", transforms.uppercase("tesT"))
+    def test_get_all_transforms(self):
+        all_transforms = transforms.get_all_transforms()
+
+        assert all_transforms == {
+            "prefix": transforms.PrefixTransformProvider,
+            "suffix": transforms.SuffixTransformProvider,
+            "strip": transforms.StripTransformProvider,
+            "lowercase": transforms.LowercaseTransformProvider,
+            "uppercase": transforms.UppercaseTransformProvider,
+        }
+
+    def test_strip(self):
+        transformer = transforms.StripTransformProvider().get_transform({}, {})
+
+        assert transformer("  test  ") == "test"
+        assert transformer("test") == "test"
+
+    def test_lowercase(self):
+        transformer = transforms.LowercaseTransformProvider().get_transform({}, {})
+
+        assert transformer("TEST") == "test"
+        assert transformer("test") == "test"
+
+    def test_uppercase(self):
+        transformer = transforms.UppercaseTransformProvider().get_transform({}, {})
+
+        assert transformer("TEST") == "TEST"
+        assert transformer("test") == "TEST"
+
+    def test_prefix(self):
+        transformer = transforms.PrefixTransformProvider().get_transform(
+            {}, {"prefix": "foo"}
+        )
+
+        assert transformer("TEST") == "fooTEST"
+        assert "prefix" in transforms.PrefixTransformProvider().get_options_schema()
+
+    def test_suffix(self):
+        transformer = transforms.SuffixTransformProvider().get_transform(
+            {}, {"suffix": "foo"}
+        )
+
+        assert transformer("TEST") == "TESTfoo"
+        assert "suffix" in transforms.SuffixTransformProvider().get_options_schema()

--- a/test/test_unit/test_transforms.py
+++ b/test/test_unit/test_transforms.py
@@ -7,35 +7,48 @@ class test_transforms(unittest.TestCase):
     def test_get_all_transforms(self):
         all_transforms = transforms.get_all_transforms()
 
-        assert all_transforms == {
-            "prefix": transforms.PrefixTransformProvider,
-            "suffix": transforms.SuffixTransformProvider,
-            "strip": transforms.StripTransformProvider,
-            "lowercase": transforms.LowercaseTransformProvider,
-            "uppercase": transforms.UppercaseTransformProvider,
+        assert all_transforms.keys() == {
+            "prefix",
+            "suffix",
+            "strip",
+            "lowercase",
+            "uppercase",
         }
+        assert isinstance(all_transforms["prefix"], transforms.PrefixTransformProvider)
+        assert isinstance(all_transforms["suffix"], transforms.SuffixTransformProvider)
+        assert isinstance(all_transforms["strip"], transforms.StripTransformProvider)
+        assert isinstance(
+            all_transforms["lowercase"], transforms.LowercaseTransformProvider
+        )
+        assert isinstance(
+            all_transforms["uppercase"], transforms.UppercaseTransformProvider
+        )
 
     def test_strip(self):
-        transformer = transforms.StripTransformProvider().get_transform({}, {})
+        transformer = transforms.StripTransformProvider().get_transform("test__c", {})
 
         assert transformer("  test  ") == "test"
         assert transformer("test") == "test"
 
     def test_lowercase(self):
-        transformer = transforms.LowercaseTransformProvider().get_transform({}, {})
+        transformer = transforms.LowercaseTransformProvider().get_transform(
+            "test__c", {}
+        )
 
         assert transformer("TEST") == "test"
         assert transformer("test") == "test"
 
     def test_uppercase(self):
-        transformer = transforms.UppercaseTransformProvider().get_transform({}, {})
+        transformer = transforms.UppercaseTransformProvider().get_transform(
+            "test__c", {}
+        )
 
         assert transformer("TEST") == "TEST"
         assert transformer("test") == "TEST"
 
     def test_prefix(self):
         transformer = transforms.PrefixTransformProvider().get_transform(
-            {}, {"prefix": "foo"}
+            "test__c", {"prefix": "foo"}
         )
 
         assert transformer("TEST") == "fooTEST"
@@ -43,7 +56,7 @@ class test_transforms(unittest.TestCase):
 
     def test_suffix(self):
         transformer = transforms.SuffixTransformProvider().get_transform(
-            {}, {"suffix": "foo"}
+            "test__c", {"suffix": "foo"}
         )
 
         assert transformer("TEST") == "TESTfoo"


### PR DESCRIPTION
This feature:

- Makes the `transforms` specifiable on each field in an operation definition extensible. Amaxa can load Python modules from the operation's directory or anywhere in PYTHONPATH that contain subclasses of `TransformProvider`. Create your own modules to add new types of transformation to Amaxa.
- Allows transforms to take options specified in the operation definition.
- Adds two new built-in transforms, `prefix` and `suffix`.
- Adds a new test data suite used in end-to-end testing of transforms.
- Adds documentation on custom transforms.

Thanks to Kyle Crouse and Doug Ayers for spurring the development of this feature and contributing helpful discussion.

Closes #29 , closes #30.