### PR TITLE
Add Serial Mode and API version options

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -73,6 +73,8 @@ jobs:
           poetry install --no-root
       - name: Run Unit Tests
         shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           poetry run tox -e py
           poetry run codecov -F unit

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pip install --upgrade pip
-          pip install poetry
-          poetry install --no-root
+          pip install --upgrade --user pip
+          pip install --user poetry
       - name: Run Unit Tests
         shell: bash
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pip install --upgrade --user pip
-          pip install --user poetry
+          pip install --upgrade pip
+          pip install poetry
+          poetry install --no-root
       - name: Run Unit Tests
         shell: bash
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -53,7 +53,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install poetry
-          poetry install --no-root
       - name: Run Unit Tests
         shell: bash
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -70,6 +70,7 @@ jobs:
         shell: bash
         run: |
           pip install poetry
+          poetry install --no-root
       - name: Run Unit Tests
         shell: bash
         run: |

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -94,11 +94,11 @@ jobs:
       - name: Build Binary
         shell: bash
         run: poetry run pyinstaller amaxa/__main__.py -n amaxa -F
-      - name: Test Binary (Windows)
+      - name: Test Binary
         if: "!startsWith(matrix.os, 'windows')"
         shell: bash
         run: ./dist/amaxa -h
-      - name: Test Binary
+      - name: Test Binary (Windows)
         if: startsWith(matrix.os, 'windows')
         shell: bash
         run: ./dist/amaxa.exe -h

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,8 @@ jobs:
             source assets/scripts/prep-scratch-org.sh
       - name: Run Tests
         shell: bash
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
             source assets/scripts/get-auth-params.sh
             poetry run tox test/test_org

--- a/amaxa/__main__.py
+++ b/amaxa/__main__.py
@@ -64,8 +64,11 @@ def main():
         and "api-version" in config["options"]
     ):
         api_version = config["options"]["api-version"]
-        if not all(
-            [len(api_version) == 4, api_version[2:] == ".0", api_version[:2].isdigit()]
+        if not (
+            type(api_version) == str
+            and len(api_version) == 4
+            and api_version[2:] == ".0"
+            and api_version[:2].isdigit()
         ):
             logger.error(f"API version {api_version} is not valid.")
             return -1

--- a/amaxa/amaxa.py
+++ b/amaxa/amaxa.py
@@ -439,6 +439,7 @@ class LoadStep(Step):
                 self.get_option("bulk-api-timeout"),
                 self.get_option("bulk-api-poll-interval"),
                 self.get_option("bulk-api-batch-size"),
+                self.get_option("bulk-api-mode"),
             )
         ):
             if r.success:
@@ -501,6 +502,7 @@ class LoadStep(Step):
                         self.get_option("bulk-api-timeout"),
                         self.get_option("bulk-api-poll-interval"),
                         self.get_option("bulk-api-batch-size"),
+                        self.get_option("bulk-api-mode"),
                     )
                 ):
                     if not r.success:

--- a/amaxa/api.py
+++ b/amaxa/api.py
@@ -6,8 +6,6 @@ from urllib.parse import urlparse
 
 import salesforce_bulk
 
-from . import constants
-
 
 def JSONIterator(records):
     def enc(r):
@@ -33,12 +31,12 @@ def BatchIterator(iterator, n=10000):
 
 
 class Connection(object):
-    def __init__(self, sf):
+    def __init__(self, sf, api_version):
         self._sf = sf
         self._bulk = salesforce_bulk.SalesforceBulk(
             sessionId=self._sf.session_id,
             host=urlparse(self._sf.bulk_url).hostname,
-            API_version=constants.API_VERSION,
+            API_version=api_version,
         )
         self._describe_info = {}
         self._field_maps = {}
@@ -106,9 +104,12 @@ class Connection(object):
         bulk_api_timeout,
         bulk_api_poll_interval,
         bulk_api_batch_size,
+        bulk_api_mode,
     ):
         yield from self._bulk_api_insert_update(
-            self._bulk.create_insert_job(sobject, contentType="JSON"),
+            self._bulk.create_insert_job(
+                sobject, contentType="JSON", concurrency=bulk_api_mode
+            ),
             sobject,
             iter(record_list),
             bulk_api_timeout,
@@ -123,9 +124,12 @@ class Connection(object):
         bulk_api_timeout,
         bulk_api_poll_interval,
         bulk_api_batch_size,
+        bulk_api_mode,
     ):
         yield from self._bulk_api_insert_update(
-            self._bulk.create_update_job(sobject, contentType="JSON"),
+            self._bulk.create_update_job(
+                sobject, contentType="JSON", concurrency=bulk_api_mode
+            ),
             sobject,
             iter(record_list),
             bulk_api_timeout,

--- a/amaxa/constants.py
+++ b/amaxa/constants.py
@@ -5,5 +5,6 @@ OPTION_DEFAULTS = {
     "bulk-api-poll-interval": 5,
     "bulk-api-timeout": 1200,
     "bulk-api-batch-size": 10000,
+    "bulk-api-mode": "Parallel",
+    "api-version": "48.0",
 }
-API_VERSION = "46.0"

--- a/amaxa/jwt_auth.py
+++ b/amaxa/jwt_auth.py
@@ -6,7 +6,7 @@ import simple_salesforce
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 
 
-def jwt_login(consumer_id, username, private_key, sandbox=False):
+def jwt_login(consumer_id, username, private_key, api_version, sandbox=False):
     endpoint = (
         "https://test.salesforce.com"
         if sandbox is True
@@ -38,5 +38,5 @@ def jwt_login(consumer_id, username, private_key, sandbox=False):
     return simple_salesforce.Salesforce(
         instance_url=body["instance_url"],
         session_id=body["access_token"],
-        version="46.0",
+        version=api_version,
     )

--- a/amaxa/loader/schemas.py
+++ b/amaxa/loader/schemas.py
@@ -69,24 +69,40 @@ def _validate_transform_options(field, value, error):
 
 
 OPTIONS_SCHEMA = {
+    "bulk-api-batch-size": {
+        "type": "integer",
+        "default": constants.OPTION_DEFAULTS["bulk-api-batch-size"],
+        "max": 10000,
+        "min": 0,
+    },
+    "bulk-api-timeout": {
+        "type": "integer",
+        "default": constants.OPTION_DEFAULTS["bulk-api-timeout"],
+        "min": 0,
+    },
+    "bulk-api-poll-interval": {
+        "type": "integer",
+        "default": constants.OPTION_DEFAULTS["bulk-api-poll-interval"],
+        "min": 0,
+        "max": 60,
+    },
+    "bulk-api-mode": {
+        "type": "string",
+        "default": constants.OPTION_DEFAULTS["bulk-api-mode"],
+        "allowed": ["Serial", "Parallel"],
+    },
+}
+
+SOBJECT_OPTIONS_SCHEMA = {"type": "dict", "schema": {**OPTIONS_SCHEMA,}}
+
+OPERATION_OPTIONS_SCHEMA = {
     "type": "dict",
     "schema": {
-        "bulk-api-batch-size": {
-            "type": "integer",
-            "default": constants.OPTION_DEFAULTS["bulk-api-batch-size"],
-            "max": 10000,
-            "min": 0,
-        },
-        "bulk-api-timeout": {
-            "type": "integer",
-            "default": constants.OPTION_DEFAULTS["bulk-api-timeout"],
-            "min": 0,
-        },
-        "bulk-api-poll-interval": {
-            "type": "integer",
-            "default": constants.OPTION_DEFAULTS["bulk-api-poll-interval"],
-            "min": 0,
-            "max": 60,
+        **OPTIONS_SCHEMA,
+        "api-version": {
+            "type": "string",
+            "default": constants.OPTION_DEFAULTS["api-version"],
+            "regex": r"\d{2}\.0",
         },
     },
 }
@@ -349,7 +365,7 @@ SCHEMAS = {
         },
         2: {
             "version": {"type": "integer", "required": True, "allowed": [2]},
-            "options": OPTIONS_SCHEMA,
+            "options": OPERATION_OPTIONS_SCHEMA,
             "plugin-modules": {
                 "type": "list",
                 "schema": {"type": "string", "check_with": _validate_import_module},
@@ -360,7 +376,7 @@ SCHEMAS = {
                     "type": "dict",
                     "schema": {
                         "sobject": {"type": "string", "required": True},
-                        "options": OPTIONS_SCHEMA,
+                        "options": SOBJECT_OPTIONS_SCHEMA,
                         "file": {
                             "type": "string",
                             "default_setter": lambda doc: doc["sobject"] + ".csv",

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -180,10 +180,12 @@ When designing an operation, it's best to think in terms of which objects are pr
 Specifying API Options
 **********************
 
-You can control how Amaxa uses the Bulk API with the ``options`` key, which can be specified at the top level of the file as well as within each step of the operation. Step-level options take precedence over operation-level options.
+You can control how Amaxa uses the Salesforce API with the ``options`` key, which can be specified at the top level of the file as well as within each step of the operation. Step-level options take precedence over operation-level options.
 
 The available options are:
 
+- ``api-version``, the Salesforce API version to use (default: 48.0). This option may be specified only at the operation level.
 - ``bulk-api-batch-size``, an integer between 0 and 10,000 (default: 10,000). This is the maximum record count of a batch uploaded by Amaxa. Reduce the batch size if your operations fail due to size errors from the Bulk API, such as ``Exceeded max size limit of 10000000`` (a limit on the total bytewise size of a batch). Note that the Bulk API batch size is not connected to the batch size used by Salesforce Data Loader when operated in REST API mode and does not impact the size of trigger invocations.
 - ``bulk-api-timeout``, an integer greater than 0 (default: 1,200). The length of time, in seconds, to wait for a Bulk API batch to complete. Defaults to 1200 seconds (20 minutes).
 - ``bulk-api-poll-interval``, an integer between 0 and 60 (default: 5). The length of time, in seconds, to wait between calls to check the Bulk API's status. Increase if you are running very large jobs and want to minimize API calls and log chatter.
+- ``bulk-api-mode``, either ``Serial`` or ``Parallel`` (default: ``Parallel`). The Bulk API mode of operation. Serial mode may be selected to resolve some concurrency issues, such as ``UNABLE_TO_LOCK_ROW``.

--- a/test/test_org/IntegrationTest.py
+++ b/test/test_org/IntegrationTest.py
@@ -7,6 +7,8 @@ from simple_salesforce.exceptions import (
     SalesforceResourceNotFound,
 )
 
+from amaxa import constants
+
 
 @unittest.skipIf(
     any(["INSTANCE_URL" not in os.environ, "ACCESS_TOKEN" not in os.environ]),
@@ -21,7 +23,7 @@ class IntegrationTest(unittest.TestCase):
         cls.connection = Salesforce(
             instance_url=os.environ["INSTANCE_URL"],
             session_id=os.environ["ACCESS_TOKEN"],
-            version="46.0",
+            version=constants.OPTION_DEFAULTS["api-version"],
         )
 
     @classmethod

--- a/test/test_org/IntegrationTest.py
+++ b/test/test_org/IntegrationTest.py
@@ -7,8 +7,6 @@ from simple_salesforce.exceptions import (
     SalesforceResourceNotFound,
 )
 
-from amaxa import constants
-
 
 @unittest.skipIf(
     any(["INSTANCE_URL" not in os.environ, "ACCESS_TOKEN" not in os.environ]),
@@ -23,7 +21,7 @@ class IntegrationTest(unittest.TestCase):
         cls.connection = Salesforce(
             instance_url=os.environ["INSTANCE_URL"],
             session_id=os.environ["ACCESS_TOKEN"],
-            version=constants.OPTION_DEFAULTS["api-version"],
+            version="48.0",
         )
 
     @classmethod

--- a/test/test_org/test_end_to_end.py
+++ b/test/test_org/test_end_to_end.py
@@ -41,7 +41,8 @@ class test_end_to_end(IntegrationTest):
                 # Read the data in so we can validate once it's re-extracted.
                 with open("test.yml", "r") as fh:
                     load_op = amaxa.loader.LoadOperationLoader(
-                        yaml.safe_load(fh.read()), amaxa.api.Connection(self.connection)
+                        yaml.safe_load(fh.read()),
+                        amaxa.api.Connection(self.connection, "48.0"),
                     )
                     load_op.load()
 

--- a/test/test_org/test_integration.py
+++ b/test/test_org/test_integration.py
@@ -43,7 +43,7 @@ class test_Integration_Extraction(IntegrationTest):
         cls.register_session_record("Contact", contact["id"])
 
     def test_all_records_extracts_accounts(self):
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         extraction = amaxa.ExtractionStep(
@@ -62,7 +62,7 @@ class test_Integration_Extraction(IntegrationTest):
             "Gemenon Gastronomy",
             "Aerilon Agrinomics",
         }
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         rec = self.connection.query(
@@ -91,7 +91,7 @@ class test_Integration_Extraction(IntegrationTest):
 
     def test_descendents_extracts_object_network(self):
         expected_names = {"Elosha", "Gaius"}
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         rec = self.connection.query(
@@ -135,7 +135,7 @@ class test_Integration_Extraction(IntegrationTest):
         }
         expected_contact_names = {"Gaius"}
 
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         rec = self.connection.query("SELECT Id FROM Contact WHERE LastName = 'Baltar'")
@@ -175,7 +175,7 @@ class test_Integration_Extraction(IntegrationTest):
         self.assertEqual(0, len(expected_account_names))
 
     def test_extracts_polymorphic_lookups(self):
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         rec = self.connection.query(
@@ -226,7 +226,7 @@ class test_Integration_Load(IntegrationTest):
             },
         ]
 
-        op = amaxa.LoadOperation(Connection(self.connection))
+        op = amaxa.LoadOperation(Connection(self.connection, "48.0"))
         op.file_store = MockFileStore()
         op.file_store.records["Product2"] = records
 
@@ -310,7 +310,7 @@ class test_Integration_Load(IntegrationTest):
             },
         ]
 
-        op = amaxa.LoadOperation(Connection(self.connection))
+        op = amaxa.LoadOperation(Connection(self.connection, "48.0"))
         op.file_store = MockFileStore()
         op.file_store.records["Account"] = accounts
         op.file_store.records["Contact"] = contacts

--- a/test/test_org/test_integration_high_volume.py
+++ b/test/test_org/test_integration_high_volume.py
@@ -5,6 +5,7 @@ from test.test_unit.MockFileStore import MockFileStore
 from simple_salesforce import Salesforce
 
 import amaxa
+from amaxa import constants
 from amaxa.api import Connection
 
 
@@ -17,7 +18,7 @@ class test_integration_high_volume(unittest.TestCase):
         self.connection = Salesforce(
             instance_url=os.environ["INSTANCE_URL"],
             session_id=os.environ["ACCESS_TOKEN"],
-            version="46.0",
+            version=constants.OPTION_DEFAULTS["api-version"],
         )
 
     def tearDown(self):

--- a/test/test_org/test_integration_high_volume.py
+++ b/test/test_org/test_integration_high_volume.py
@@ -42,7 +42,7 @@ class test_integration_high_volume(unittest.TestCase):
                 }
             )
 
-        op = amaxa.LoadOperation(Connection(self.connection))
+        op = amaxa.LoadOperation(Connection(self.connection, "48.0"))
         op.file_store = MockFileStore()
         op.file_store.records["Lead"] = records
         op.add_step(amaxa.LoadStep("Lead", set(["LastName", "Company"])))
@@ -54,7 +54,7 @@ class test_integration_high_volume(unittest.TestCase):
             100000, self.connection.query("SELECT count() FROM Lead").get("totalSize")
         )
 
-        oc = amaxa.ExtractOperation(Connection(self.connection))
+        oc = amaxa.ExtractOperation(Connection(self.connection, "48.0"))
         oc.file_store = MockFileStore()
 
         extraction = amaxa.ExtractionStep(

--- a/test/test_unit/MockConnection.py
+++ b/test/test_unit/MockConnection.py
@@ -58,6 +58,7 @@ class MockConnection(object):
         bulk_api_timeout,
         bulk_api_poll_interval,
         bulk_api_batch_size,
+        bulk_api_mode,
     ):
         for r in self._bulk_insert_results:
             yield r
@@ -69,6 +70,7 @@ class MockConnection(object):
         bulk_api_timeout,
         bulk_api_poll_interval,
         bulk_api_batch_size,
+        bulk_api_mode,
     ):
         for r in self._bulk_update_results:
             yield r

--- a/test/test_unit/test_Connection.py
+++ b/test/test_unit/test_Connection.py
@@ -14,19 +14,17 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        Connection(sf)
+        Connection(sf, api_version="48.0")
 
         bulk_mock.assert_called_once_with(
-            sessionId=sf.session_id,
-            host="salesforce.com",
-            API_version=amaxa.constants.API_VERSION,
+            sessionId=sf.session_id, host="salesforce.com", API_version="48.0",
         )
 
     def test_get_global_describe_calls_salesforce(self):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         self.assertEqual(sf.describe.return_value, conn.get_global_describe())
 
         sf.describe.assert_called_once_with()
@@ -35,7 +33,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         sf.Account.describe.return_value = {
             "fields": [{"name": "Name"}, {"name": "Id"}]
         }
@@ -49,7 +47,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         sf.Account.describe.return_value = {
             "fields": [{"name": "Name"}, {"name": "Id"}]
         }
@@ -67,7 +65,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         sf.Account.describe.return_value = {
             "fields": [{"name": "Name"}, {"name": "Id"}]
         }
@@ -85,7 +83,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn.get_global_describe = Mock()
         conn.get_global_describe.return_value = {
             "sobjects": [
@@ -103,7 +101,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn._bulk = Mock()
 
         retval = [{"Id": "001000000000001"}, {"Id": "001000000000002"}]
@@ -131,7 +129,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn._bulk = Mock()
 
         retval = [
@@ -160,14 +158,16 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn._bulk = Mock()
         conn._bulk_api_insert_update = Mock(return_value=[])
 
-        self.assertEqual([], list(conn.bulk_api_insert("Account", [], 120, 5, 1)))
+        self.assertEqual(
+            [], list(conn.bulk_api_insert("Account", [], 120, 5, 1, "Parallel"))
+        )
 
         conn._bulk.create_insert_job.assert_called_once_with(
-            "Account", contentType="JSON"
+            "Account", contentType="JSON", concurrency="Parallel"
         )
 
         conn._bulk_api_insert_update.assert_called_once()
@@ -184,14 +184,16 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
 
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn._bulk = Mock()
         conn._bulk_api_insert_update = Mock(return_value=[])
 
-        self.assertEqual([], list(conn.bulk_api_update("Account", [], 120, 5, 1)))
+        self.assertEqual(
+            [], list(conn.bulk_api_update("Account", [], 120, 5, 1, "Parallel"))
+        )
 
         conn._bulk.create_update_job.assert_called_once_with(
-            "Account", contentType="JSON"
+            "Account", contentType="JSON", concurrency="Parallel"
         )
 
         conn._bulk_api_insert_update.assert_called_once()
@@ -207,7 +209,7 @@ class test_Connection(unittest.TestCase):
     def test_bulk_api_insert_update(self):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
         conn._bulk = Mock()
         job = Mock()
 
@@ -276,7 +278,7 @@ class test_Connection(unittest.TestCase):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
         sf.restful = Mock(side_effect=api_return_value)
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
 
         retval = conn.retrieve_records_by_id("Account", id_set, ["Name"])
         self.assertEqual(complete_return_value, list(retval))
@@ -301,7 +303,7 @@ class test_Connection(unittest.TestCase):
     def test_query_records_by_reference_field(self):
         sf = Mock()
         sf.bulk_url = "https://salesforce.com"
-        conn = Connection(sf)
+        conn = Connection(sf, "48.0")
 
         id_set = []
         for i in range(400):

--- a/test/test_unit/test_CredentialLoader.py
+++ b/test/test_unit/test_CredentialLoader.py
@@ -12,7 +12,7 @@ class test_CredentialLoader(unittest.TestCase):
             with patch("salesforce_bulk.SalesforceBulk"):
                 sf_mock.return_value.bulk_url = "https://salesforce.com"
 
-                credential_loader = loader.CredentialLoader(input_data)
+                credential_loader = loader.CredentialLoader(input_data, "48.0")
 
                 credential_loader.load()
                 self.assertEqual([], credential_loader.errors)
@@ -23,7 +23,7 @@ class test_CredentialLoader(unittest.TestCase):
             with patch("salesforce_bulk.SalesforceBulk"):
                 sf_mock.return_value.bulk_url = "https://salesforce.com"
 
-                credential_loader = loader.CredentialLoader(input_data)
+                credential_loader = loader.CredentialLoader(input_data, "48.0")
 
                 credential_loader.load()
                 if type(errors) is list:
@@ -38,13 +38,13 @@ class test_CredentialLoader(unittest.TestCase):
             with patch("salesforce_bulk.SalesforceBulk"):
                 sf_mock.return_value.bulk_url = "https://salesforce.com"
 
-                credential_loader = loader.CredentialLoader(input_data)
+                credential_loader = loader.CredentialLoader(input_data, "48.0")
 
                 credential_loader.load()
                 self.assertEqual([], credential_loader.errors)
                 self.assertIsNotNone(credential_loader.result)
 
-                sf_mock.assert_called_once_with(version="46.0", **arguments)
+                sf_mock.assert_called_once_with(version="48.0", **arguments)
 
     def test_credential_schema_validates_username_password_v1(self):
         self._run_validation_test(
@@ -574,7 +574,7 @@ class test_CredentialLoader(unittest.TestCase):
         )
 
     def test_load_credentials_traps_login_errors(self):
-        credentials = loader.CredentialLoader({})
+        credentials = loader.CredentialLoader({}, "48.0")
 
         side_effect = simple_salesforce.SalesforceError(
             "https://salesforce.com", 401, "describe", ""

--- a/test/test_unit/test_LoadStep.py
+++ b/test/test_unit/test_LoadStep.py
@@ -338,6 +338,7 @@ class test_LoadStep(unittest.TestCase):
             load_step.get_option("bulk-api-timeout"),
             load_step.get_option("bulk-api-poll-interval"),
             load_step.get_option("bulk-api-batch-size"),
+            load_step.get_option("bulk-api-mode"),
         )
         op.register_new_id.assert_has_calls(
             [
@@ -411,6 +412,7 @@ class test_LoadStep(unittest.TestCase):
             load_step.get_option("bulk-api-timeout"),
             load_step.get_option("bulk-api-poll-interval"),
             load_step.get_option("bulk-api-batch-size"),
+            load_step.get_option("bulk-api-mode"),
         )
         op.register_new_id.assert_has_calls(
             [
@@ -636,6 +638,7 @@ class test_LoadStep(unittest.TestCase):
             load_step.get_option("bulk-api-timeout"),
             load_step.get_option("bulk-api-poll-interval"),
             load_step.get_option("bulk-api-batch-size"),
+            load_step.get_option("bulk-api-mode"),
         )
 
     def test_execute_dependent_updates_handles_errors(self):
@@ -765,6 +768,7 @@ class test_LoadStep(unittest.TestCase):
             load_step.get_option("bulk-api-timeout"),
             load_step.get_option("bulk-api-poll-interval"),
             load_step.get_option("bulk-api-batch-size"),
+            load_step.get_option("bulk-api-mode"),
         )
         op.register_new_id.assert_has_calls(
             [
@@ -863,6 +867,7 @@ class test_LoadStep(unittest.TestCase):
                 "bulk-api-poll-interval": 10,
                 "bulk-api-timeout": 600,
                 "bulk-api-batch-size": 5000,
+                "bulk-api-mode": "Serial",
             },
         )
         step.context = op
@@ -873,7 +878,7 @@ class test_LoadStep(unittest.TestCase):
         step.execute()
 
         op.connection.bulk_api_insert.assert_called_once_with(
-            "Account", cleaned_record_list, 600, 10, 5000
+            "Account", cleaned_record_list, 600, 10, 5000, "Serial"
         )
 
     def test_execute_dependent_updates_uses_bulk_api_options(self):
@@ -917,6 +922,7 @@ class test_LoadStep(unittest.TestCase):
                 "bulk-api-poll-interval": 10,
                 "bulk-api-timeout": 600,
                 "bulk-api-batch-size": 5000,
+                "bulk-api-mode": "Serial",
             },
         )
         op.add_step(load_step)
@@ -925,5 +931,5 @@ class test_LoadStep(unittest.TestCase):
         load_step.execute_dependent_updates()
 
         op.connection.bulk_api_update.assert_called_once_with(
-            "Account", cleaned_record_list, 600, 10, 5000
+            "Account", cleaned_record_list, 600, 10, 5000, "Serial"
         )

--- a/test/test_unit/test_cli.py
+++ b/test/test_unit/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import yaml
 
 import amaxa
+from amaxa import constants
 from amaxa.__main__ import main
 
 CREDENTIALS_GOOD_YAML = """
@@ -134,7 +135,9 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(json.loads(CREDENTIALS_GOOD_JSON))
+        credential_mock.assert_called_once_with(
+            json.loads(CREDENTIALS_GOOD_JSON), constants.OPTION_DEFAULTS["api-version"]
+        )
         operation_mock.assert_called_once_with(
             json.loads(EXTRACTION_GOOD_JSON), context
         )
@@ -171,7 +174,9 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(json.loads(CREDENTIALS_GOOD_JSON))
+        credential_mock.assert_called_once_with(
+            json.loads(CREDENTIALS_GOOD_JSON), constants.OPTION_DEFAULTS["api-version"]
+        )
         operation_mock.assert_called_once_with(
             json.loads(EXTRACTION_GOOD_JSON), context, use_state=False
         )
@@ -200,7 +205,10 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(yaml.safe_load(CREDENTIALS_GOOD_YAML))
+        credential_mock.assert_called_once_with(
+            yaml.safe_load(CREDENTIALS_GOOD_YAML),
+            constants.OPTION_DEFAULTS["api-version"],
+        )
         operation_mock.assert_called_once_with(
             yaml.safe_load(EXTRACTION_GOOD_YAML), context
         )
@@ -230,7 +238,9 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(yaml.safe_load(CREDENTIALS_BAD))
+        credential_mock.assert_called_once_with(
+            yaml.safe_load(CREDENTIALS_BAD), constants.OPTION_DEFAULTS["api-version"]
+        )
         context.run.assert_not_called()
 
         self.assertEqual(-1, return_value)
@@ -256,7 +266,10 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(yaml.safe_load(CREDENTIALS_GOOD_YAML))
+        credential_mock.assert_called_once_with(
+            yaml.safe_load(CREDENTIALS_GOOD_YAML),
+            constants.OPTION_DEFAULTS["api-version"],
+        )
         operation_mock.assert_called_once_with(yaml.safe_load(EXTRACTION_BAD), context)
 
         self.assertEqual(-1, return_value)
@@ -288,7 +301,10 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(yaml.safe_load(CREDENTIALS_GOOD_YAML))
+        credential_mock.assert_called_once_with(
+            yaml.safe_load(CREDENTIALS_GOOD_YAML),
+            constants.OPTION_DEFAULTS["api-version"],
+        )
         state_mock.assert_called_once_with(
             yaml.safe_load(STATE_GOOD_YAML), operation_mock.return_value.result
         )
@@ -444,7 +460,9 @@ class test_CLI(unittest.TestCase):
             ):
                 return_value = main()
 
-        credential_mock.assert_called_once_with(json.loads(CREDENTIALS_GOOD_JSON))
+        credential_mock.assert_called_once_with(
+            json.loads(CREDENTIALS_GOOD_JSON), constants.OPTION_DEFAULTS["api-version"]
+        )
         operation_mock.assert_called_once_with(
             json.loads(EXTRACTION_GOOD_JSON), context
         )


### PR DESCRIPTION
This PR adds new options keys to the operation definition:

- `api-version` selects the API version for all Salesforce APIs (configurable at operation level only)
- `bulk-api-mode` selects whether to use `Serial` or `Parallel` mode in the Bulk API (configurable at operation and sObject level)