### PR TITLE
Explicit encoding on all open() calls

### DIFF
--- a/amaxa/__main__.py
+++ b/amaxa/__main__.py
@@ -122,6 +122,7 @@ def main():
             + ".state"
             + (".json" if json_mode else ".yaml"),
             "w",
+            encoding="utf-8",
         ) as state_file:
             state_file.write(save_state(ex, json_mode))
 

--- a/amaxa/loader/credentials.py
+++ b/amaxa/loader/credentials.py
@@ -58,7 +58,7 @@ class CredentialLoader(Loader):
         elif "username" in credentials and "jwt-file" in credentials:
             # JWT authentication with external keyfile.
             try:
-                with open(credentials["jwt-file"], "r") as jwt_file:
+                with open(credentials["jwt-file"], "r", encoding="utf-8") as jwt_file:
                     self.result = jwt_auth.jwt_login(
                         credentials["consumer-key"],
                         credentials["username"],
@@ -112,7 +112,7 @@ class CredentialLoader(Loader):
             credentials = credentials["jwt"]
             if "keyfile" in credentials:
                 # JWT authentication with external keyfile
-                with open(credentials["keyfile"], "r") as jwt_file:
+                with open(credentials["keyfile"], "r", encoding="utf-8") as jwt_file:
                     key = jwt_file.read()
 
                 logging.getLogger("amaxa").debug(

--- a/amaxa/loader/extract_operation.py
+++ b/amaxa/loader/extract_operation.py
@@ -127,7 +127,7 @@ class ExtractionOperationLoader(OperationLoader):
         # Create DictWriters and populate them in the context
         for (step, entry) in zip(self.result.steps, self.input["operation"]):
             try:
-                file_handle = open(entry["file"], "w", newline="")
+                file_handle = open(entry["file"], "w", newline="", encoding="utf-8")
                 if step.sobjectname not in self.result.mappers:
                     fieldnames = step.field_scope
                 else:

--- a/amaxa/loader/load_operation.py
+++ b/amaxa/loader/load_operation.py
@@ -85,7 +85,7 @@ class LoadOperationLoader(OperationLoader):
         # Create DictReaders and populate them in the context
         for (step, entry) in zip(self.result.steps, self.input["operation"]):
             try:
-                file_handle = open(entry["file"], "r")
+                file_handle = open(entry["file"], "r", encoding="utf-8")
                 input_file = csv.DictReader(file_handle)
                 self.result.file_store.set_file(
                     step.sobjectname, amaxa.FileType.INPUT, file_handle
@@ -102,7 +102,10 @@ class LoadOperationLoader(OperationLoader):
 
             try:
                 f = open(
-                    entry["result-file"], "w" if not self.use_state else "a", newline=""
+                    entry["result-file"],
+                    "w" if not self.use_state else "a",
+                    newline="",
+                    encoding="utf-8",
                 )
                 output = csv.DictWriter(
                     f,

--- a/assets/scripts/prep-scratch-org.sh
+++ b/assets/scripts/prep-scratch-org.sh
@@ -1,2 +1,3 @@
 sfdx force:org:create -s -f assets/project-scratch-def.json -a amaxa
+sfdx force:apex:execute -f assets/scripts/remove-junk-records.apex -u amaxa
 source assets/scripts/get-auth-params.sh

--- a/assets/scripts/remove-junk-records.apex
+++ b/assets/scripts/remove-junk-records.apex
@@ -1,0 +1,2 @@
+delete [SELECT Id FROM Entitlement];
+delete [SELECT Id FROM Account];

--- a/test/test_org/test_end_to_end.py
+++ b/test/test_org/test_end_to_end.py
@@ -39,7 +39,7 @@ class test_end_to_end(IntegrationTest):
                     self.assertEqual(0, main())
 
                 # Read the data in so we can validate once it's re-extracted.
-                with open("test.yml", "r") as fh:
+                with open("test.yml", "r", encoding="utf-8") as fh:
                     load_op = amaxa.loader.LoadOperationLoader(
                         yaml.safe_load(fh.read()),
                         amaxa.api.Connection(self.connection, "48.0"),
@@ -54,7 +54,9 @@ class test_end_to_end(IntegrationTest):
                     # For each object, look at the CSV to determine the record count
                     # and the name field(s) we should verify.
 
-                    with open("{}.csv".format(sobject), "r") as csv_file:
+                    with open(
+                        "{}.csv".format(sobject), "r", encoding="utf-8"
+                    ) as csv_file:
                         reader = csv.DictReader(csv_file)
                         for record in reader:
                             counts[sobject] = counts[sobject] + 1
@@ -71,7 +73,9 @@ class test_end_to_end(IntegrationTest):
 
                 # Validate the results
                 for sobject in sobject_list:
-                    with open("{}.csv".format(sobject), "r") as csv_file:
+                    with open(
+                        "{}.csv".format(sobject), "r", encoding="utf-8"
+                    ) as csv_file:
                         reader = csv.DictReader(csv_file)
                         for record in reader:
                             self.register_case_record(sobject, record["Id"])
@@ -116,7 +120,7 @@ class test_end_to_end_transforms(IntegrationTest):
                     self.assertEqual(0, main())
 
                 # Validate the results
-                with open("Account.csv", "r") as csv_file:
+                with open("Account.csv", "r", encoding="utf-8") as csv_file:
                     reader = csv.DictReader(csv_file)
                     for record in reader:
                         self.register_case_record("Account", record["Id"])

--- a/test/test_unit/MockConnection.py
+++ b/test/test_unit/MockConnection.py
@@ -5,11 +5,17 @@ import os.path
 sobject_describes = {}
 sobject_list = ["Account", "Contact", "Opportunity", "Task", "Attachment"]
 
-with open(os.path.join("assets", "test_describes", "sobjects.json"), "r") as d:
+with open(
+    os.path.join("assets", "test_describes", "sobjects.json"), "r", encoding="utf-8"
+) as d:
     root_describe = json.load(d)
 
 for sobject in sobject_list:
-    with open(os.path.join("assets", "test_describes", f"{sobject}.json"), "r") as d:
+    with open(
+        os.path.join("assets", "test_describes", f"{sobject}.json"),
+        "r",
+        encoding="utf-8",
+    ) as d:
         sobject_describes[sobject] = json.load(d)
 
 

--- a/test/test_unit/test_CredentialLoader.py
+++ b/test/test_unit/test_CredentialLoader.py
@@ -195,7 +195,7 @@ class test_CredentialLoader(unittest.TestCase):
                 {"session_id": "swordfish", "instance_url": "test.salesforce.com"},
             )
 
-        m.assert_any_call("jwt.key", "r")
+        m.assert_any_call("jwt.key", "r", encoding="utf-8")
         jwt_mock.assert_called()
         requests_mock.assert_called_once_with(
             "https://test.salesforce.com/services/oauth2/token",
@@ -483,7 +483,7 @@ class test_CredentialLoader(unittest.TestCase):
                 {"session_id": "swordfish", "instance_url": "test.salesforce.com"},
             )
 
-        m.assert_any_call("jwt.key", "r")
+        m.assert_any_call("jwt.key", "r", encoding="utf-8")
         jwt_mock.assert_called()
         requests_mock.assert_called_once_with(
             "https://test.salesforce.com/services/oauth2/token",

--- a/test/test_unit/test_ExtractionOperationLoader.py
+++ b/test/test_unit/test_ExtractionOperationLoader.py
@@ -459,10 +459,12 @@ class test_ExtractionOperationLoader(unittest.TestCase):
 
         m.assert_has_calls(
             [
-                unittest.mock.call("Account.csv", "w", newline=""),
-                unittest.mock.call("Contact.csv", "w", newline=""),
-                unittest.mock.call("Opportunity.csv", "w", newline=""),
-                unittest.mock.call("Task.csv", "w", newline=""),
+                unittest.mock.call("Account.csv", "w", newline="", encoding="utf-8"),
+                unittest.mock.call("Contact.csv", "w", newline="", encoding="utf-8"),
+                unittest.mock.call(
+                    "Opportunity.csv", "w", newline="", encoding="utf-8"
+                ),
+                unittest.mock.call("Task.csv", "w", newline="", encoding="utf-8"),
             ],
             any_order=True,
         )

--- a/test/test_unit/test_LoadOperationLoader.py
+++ b/test/test_unit/test_LoadOperationLoader.py
@@ -587,14 +587,22 @@ class test_LoadOperationLoader(unittest.TestCase):
 
         m.assert_has_calls(
             [
-                unittest.mock.call("Account.csv", "r"),
-                unittest.mock.call("Contact.csv", "r"),
-                unittest.mock.call("Opportunity.csv", "r"),
-                unittest.mock.call("Task.csv", "r"),
-                unittest.mock.call("Account-results.csv", "w", newline=""),
-                unittest.mock.call("Contact-results.csv", "w", newline=""),
-                unittest.mock.call("Opportunity-results.csv", "w", newline=""),
-                unittest.mock.call("Task-results.csv", "w", newline=""),
+                unittest.mock.call("Account.csv", "r", encoding="utf-8"),
+                unittest.mock.call("Contact.csv", "r", encoding="utf-8"),
+                unittest.mock.call("Opportunity.csv", "r", encoding="utf-8"),
+                unittest.mock.call("Task.csv", "r", encoding="utf-8"),
+                unittest.mock.call(
+                    "Account-results.csv", "w", newline="", encoding="utf-8"
+                ),
+                unittest.mock.call(
+                    "Contact-results.csv", "w", newline="", encoding="utf-8"
+                ),
+                unittest.mock.call(
+                    "Opportunity-results.csv", "w", newline="", encoding="utf-8"
+                ),
+                unittest.mock.call(
+                    "Task-results.csv", "w", newline="", encoding="utf-8"
+                ),
             ],
             any_order=True,
         )
@@ -629,8 +637,10 @@ class test_LoadOperationLoader(unittest.TestCase):
 
         m.assert_has_calls(
             [
-                unittest.mock.call("Account.csv", "r"),
-                unittest.mock.call("Account-results.csv", "w", newline=""),
+                unittest.mock.call("Account.csv", "r", encoding="utf-8"),
+                unittest.mock.call(
+                    "Account-results.csv", "w", newline="", encoding="utf-8"
+                ),
             ],
             any_order=True,
         )
@@ -662,8 +672,10 @@ class test_LoadOperationLoader(unittest.TestCase):
 
         m.assert_has_calls(
             [
-                unittest.mock.call("Account.csv", "r"),
-                unittest.mock.call("Account-results.csv", "a", newline=""),
+                unittest.mock.call("Account.csv", "r", encoding="utf-8"),
+                unittest.mock.call(
+                    "Account-results.csv", "a", newline="", encoding="utf-8"
+                ),
             ],
             any_order=True,
         )

--- a/test/test_unit/test_transforms.py
+++ b/test/test_unit/test_transforms.py
@@ -12,7 +12,11 @@ class test_transforms(unittest.TestCase):
     def test_get_all_transforms(self):
         all_transforms = transforms.get_all_transforms()
 
-        assert all_transforms.keys() == {
+        # If integration tests have been run first, we may have an example transform present.
+        transform_keys = set(all_transforms.keys())
+        if "multiply" in transform_keys:
+            transform_keys.remove("multiply")
+        assert transform_keys == {
             "prefix",
             "suffix",
             "strip",


### PR DESCRIPTION
This PR should fix issues on Windows where the default encoding is not UTF-8.

Closes #48 .